### PR TITLE
feat: Add locale column to vocabulary entries list

### DIFF
--- a/app/Filament/Resources/VocabularyEntryResource.php
+++ b/app/Filament/Resources/VocabularyEntryResource.php
@@ -115,6 +115,15 @@ class VocabularyEntryResource extends Resource
     {
         return $table
             ->columns([
+                TextColumn::make('all_locales_list') // New name, moved to the beginning
+                    ->label('Locales Available') // Changed label slightly for clarity
+                    ->getStateUsing(function (VocabularyEntry $record) {
+                        if ($record->entry_labels && is_array($record->entry_labels) && count($record->entry_labels) > 0) {
+                            return implode(', ', array_keys($record->entry_labels));
+                        }
+                        return '[N/A]';
+                    })
+                    ->sortable(false),
                 TextColumn::make('rank')->label('Ordre')->sortable(),
                 TextColumn::make('entry_labels.fr')
                     ->label('Libellé')

--- a/app/Filament/Resources/VocabularyResource/RelationManagers/EntriesRelationManager.php
+++ b/app/Filament/Resources/VocabularyResource/RelationManagers/EntriesRelationManager.php
@@ -124,6 +124,15 @@ class VocabularyEntriesRelationManager extends RelationManager
                         )
                     )
                     ->sortable(),
+                TextColumn::make('available_locales')
+                    ->label('Locales')
+                    ->getStateUsing(function (VocabularyEntry $record) {
+                        if ($record->entry_labels && is_array($record->entry_labels) && count($record->entry_labels) > 0) {
+                            return implode(', ', array_keys($record->entry_labels));
+                        }
+                        return '[N/A]';
+                    })
+                    ->sortable(false),
                 TextColumn::make('entry_value')->label('Slug'),
             ])
             ->defaultSort('rank')


### PR DESCRIPTION
Adds a 'Locales' column to the table display of vocabulary entries when viewed within a Vocabulary resource (via EntriesRelationManager). This column lists all available locales for each entry, derived from the keys in the `entry_labels` JSON field.

The column is implemented using `getStateUsing` to dynamically generate the comma-separated list of locales. A fallback of '[N/A]' is displayed if an entry has no defined locales.

Changes were made in:
- `app/Filament/Resources/VocabularyResource/RelationManagers/EntriesRelationManager.php` (primary change for the working feature)
- `app/Filament/Resources/VocabularyEntryResource.php` (similar changes made during debugging; may be useful if this resource's table is used directly)